### PR TITLE
Changed payment to standby custodians from linear to upward slope

### DIFF
--- a/newperiod_components.cpp
+++ b/newperiod_components.cpp
@@ -1,3 +1,4 @@
+#include <math.h> 
 
 void daccustodian::distributePay() {
     custodians_table custodians(_self, _self.value);
@@ -79,9 +80,9 @@ void daccustodian::distributeMeanPay() {
             }
 
             if (cand_itr->total_votes==0)
-                standbypay.amount = meanAsset.amount/numzerovotes;
+                standbypay.amount = meanAsset.amount * pow((double)1.0/(double)firstcandvotes, 2.0) / 5; // 0 Votes get 1/5 of 1 vote
             else
-                standbypay.amount = meanAsset.amount * ((double)cand_itr->total_votes/(double)firstcandvotes);
+                standbypay.amount = meanAsset.amount * pow((double)cand_itr->total_votes/(double)firstcandvotes, 2.0);
 
             pending_pay.emplace(_self, [&](pay &p) {
                 p.key = pending_pay.available_primary_key();

--- a/newperiod_components.cpp
+++ b/newperiod_components.cpp
@@ -80,7 +80,8 @@ void daccustodian::distributeMeanPay() {
             }
 
             if (cand_itr->total_votes==0)
-                standbypay.amount = meanAsset.amount * pow((double)1.0/(double)firstcandvotes, 2.0) / 5; // 0 Votes get 1/5 of 1 vote
+                // Candidates with 0 Votes get minimum between [1/5 of 1 vote payment] and [Custodian payment divided by number of 0 votes]
+                standbypay.amount = std::min<double>((double)meanAsset.amount * pow((double)1.0/(double)firstcandvotes, 2.0) / 5, meanAsset.amount/numzerovotes);
             else
                 standbypay.amount = meanAsset.amount * pow((double)cand_itr->total_votes/(double)firstcandvotes, 2.0);
 


### PR DESCRIPTION
Instead of being paid:
meanAsset.amount * ((double)cand_itr->total_votes/(double)firstcandvotes)
now payment is:
meanAsset.amount * ((double)cand_itr->total_votes/(double)firstcandvotes)^2

Candidates with 0 votes get 1/5 of the payment of those with 1 vote.
resloves #3